### PR TITLE
Remove static folder from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
-static/
+.vscode/
+.DS_Store
 db/
 client_secrets.json
 prueba.py
-.vscode/
-venv/
-.DS_Store
 static/.webassets-cache/
 static/img/
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-.vscode/
 .DS_Store
-db/
+.vscode/
 client_secrets.json
+db/
 prueba.py
 static/.webassets-cache/
 static/img/


### PR DESCRIPTION
@laramaktub the `static/` folder should not be added currently as a whole to `.gitignore`, as there are certain folders and files whose changes need to be tracked for the correct functioning of Frontend.
If required, add to `.gitignore` only the subfolders from `static/` that shall not be tracked.

Other changes:
*  Rearranged alphabetically contents to be ignored.